### PR TITLE
Disable scanning by default; slight improvements to external flash documentation.

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/external_flash.c
+++ b/firmware/nRF_badge/data_collector/incl/external_flash.c
@@ -102,7 +102,7 @@ unsigned char dummyRxBuf[1];
 //enable writes to flash chip, needed before any writing command (status reg write, page erase, array write, etc)
 static void ext_flash_WEL()
 {
-    uint8_t txBuf[1] = {0x06};      //enable flash write
+    uint8_t txBuf[1] = {WEL_OPCODE};      //enable flash write
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),dummyRxBuf,0);
     while(spi_busy());
 }
@@ -113,8 +113,8 @@ uint32_t ext_flash_global_unprotect()
         return EXT_FLASH_ERR_BUSY;
     }
     ext_flash_WEL();
-                    //  opcode  global unprotect
-    uint8_t txBuf[2] = {0x01,   0x00};          //Write to status register
+                    //  opcode              global unprotect
+    uint8_t txBuf[2] = {WRITESREG_OPCODE,   0x00};          //Write to status register
     extFlashState = EXT_FLASH_COMMAND;
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),dummyRxBuf,0);
     return EXT_FLASH_SUCCESS;
@@ -126,7 +126,7 @@ uint8_t ext_flash_read_status()
         return EXT_FLASH_ERR_BUSY;
     }
                     //  opcode
-    uint8_t txBuf[1] = {0x05};
+    uint8_t txBuf[1] = {READSREG_OPCODE};
     uint8_t rxBuf[2] = {0,0};
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),rxBuf,2);
     while(spi_busy());
@@ -139,7 +139,7 @@ uint32_t ext_flash_read_MFID()
         return EXT_FLASH_ERR_BUSY;
     }
                     //  opcode
-    uint8_t txBuf[1] = {0x9f};
+    uint8_t txBuf[1] = {READMFID_OPCODE};
     uint8_t rxBuf[5] = {0,0,0,0,0};
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),rxBuf,5);
     while(spi_busy());
@@ -152,8 +152,8 @@ uint32_t ext_flash_read_OTP(unsigned int address, uint8_t* rx, unsigned int numB
     if(extFlashState != EXT_FLASH_SPI_IDLE)  {
         return EXT_FLASH_ERR_BUSY;
     }
-                    //  opcode  address                                             dummy
-    uint8_t txBuf[6] = {0x77,   (address>>16)&0xff,(address>>8)&0xff,address&0xff,  0x00,0x00};
+                    //  opcode           address                                             dummy
+    uint8_t txBuf[6] = {READOTP_OPCODE,  (address>>16)&0xff,(address>>8)&0xff,address&0xff,  0x00,0x00};
     extFlashState = EXT_FLASH_READ;
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),rx,numBytes);
     return EXT_FLASH_SUCCESS;
@@ -165,8 +165,8 @@ uint32_t ext_flash_read(unsigned int address, uint8_t* rx, unsigned int numBytes
     if(extFlashState != EXT_FLASH_SPI_IDLE)  {
         return EXT_FLASH_ERR_BUSY;
     }
-                    //  opcode  address
-    uint8_t txBuf[4] = {0x03,   (address>>16)&0xff,(address>>8)&0xff,address&0xff};
+                    //  opcode        address
+    uint8_t txBuf[4] = {READ_OPCODE,  (address>>16)&0xff,(address>>8)&0xff,address&0xff};
     extFlashState = EXT_FLASH_READ;
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),rx,numBytes);
     return EXT_FLASH_SUCCESS;
@@ -207,7 +207,7 @@ uint32_t ext_flash_write(unsigned int address, uint8_t* txRaw, unsigned int numB
         return EXT_FLASH_ERR_BUSY;
     }
     ext_flash_WEL();  //enable writes
-    txRaw[0] = 0x02;  //opcode
+    txRaw[0] = WRITE_OPCODE;  //opcode
     //address bytes
     txRaw[1] = (address>>16)&0xff;
     txRaw[2] = (address>>8)&0xff;
@@ -226,8 +226,8 @@ uint32_t ext_flash_block_erase(uint32_t address)
     }
     ext_flash_WEL();  //enable writes
     
-                    //  opcode  address bytes
-    uint8_t txBuf[4] = {0x20,   (address>>16)&0xff,(address>>8)&0xff,address&0xff};
+                    //  opcode              address bytes
+    uint8_t txBuf[4] = {BLOCKERASE_OPCODE,  (address>>16)&0xff,(address>>8)&0xff,address&0xff};
     extFlashState = EXT_FLASH_COMMAND;
     spi_master_send_recv(SPI_MASTER_0,txBuf,sizeof(txBuf),dummyRxBuf,0);
     return EXT_FLASH_SUCCESS;

--- a/firmware/nRF_badge/data_collector/incl/external_flash.h
+++ b/firmware/nRF_badge/data_collector/incl/external_flash.h
@@ -27,11 +27,33 @@
 #include "nrf_drv_config.h"
 #include "boards.h"
 
-#define EXT_FLASH_SREG_BUSY 0x1         //bit in flash status register indicating an in-progress write or erase
-#define EXT_FLASH_SREG_WEL 0x2          //write enable bit
-#define EXT_FLASH_SREG_WPP 0x10         //state of write protect pin (active low)
-#define EXT_FLASH_SREG_EPE 0x20         //erase/program error
-#define EXT_FLASH_SREG_SPRL 0x80        //sector protect register lock
+
+// The following opcodes are common to both the ATXE flash and M95 EEPROM
+#define WEL_OPCODE        0x06          // enable write
+#define WRITESREG_OPCODE  0x01          // write to status register
+#define READSREG_OPCODE   0x05          // read status register
+#define WRITE_OPCODE      0x02          // write to main memory
+#define READ_OPCODE       0x03          // read from main memory
+
+// The following opcodes are exclusive to the ATXE flash - the M95 EEPROM will ignore them
+#define BLOCKERASE_OPCODE 0x20          // erase 4kByte block of memory
+#define READMFID_OPCODE   0x9f          // read manufacturer ID
+#define READOTP_OPCODE    0x77          // read one-time-programmable memory (includes some ID data)
+
+
+
+// The following status register flags are common to both the ATXE flash and M95 EEPROM
+#define EXT_FLASH_SREG_BUSY 0x1         // bit in flash status register indicating an in-progress write or erase
+#define EXT_FLASH_SREG_WEL  0x2         // write enable bit
+#define EXT_FLASH_SREG_PR0  0x04        // block/sector protect bit 0
+#define EXT_FLASH_SREG_PR1  0x08        // block/sector protect bit 1
+#define EXT_FLASH_SREG_SPRL 0x80        // sector protect register lock / status register lock
+
+// The following status register flags are exclusive to the ATXE flash - always 0 on M95 EEPROM
+#define EXT_FLASH_SREG_WPP  0x10        // state of write protect pin (active low)
+#define EXT_FLASH_SREG_EPE  0x20        // erase/program error
+#define EXT_FLASH_SREG_SPRG 0x40        // sequential program mode - unused here
+
 
 typedef enum
 {

--- a/firmware/nRF_badge/data_collector/incl/scanning.c
+++ b/firmware/nRF_badge/data_collector/incl/scanning.c
@@ -202,6 +202,10 @@ void scans_init()
     scanTiming.window = SCAN_WINDOW;
     scanTiming.timeout = SCAN_TIMEOUT;
     scanTiming.period = SCAN_PERIOD;
+    
+    scan_enable = false;  //default to no scanning
+    scan_state = SCAN_IDLE;
+    
 }
 
 
@@ -247,7 +251,6 @@ void startScan(int interval_ms, int window_ms, int timeout_s)
     sd_ble_gap_scan_start(&scan_params);
     
     scan_state = SCAN_SCANNING;
-    
     //debug_log("Scan started\r\n");
 }
     
@@ -303,9 +306,12 @@ void updateScanning()
     {
         case SCAN_IDLE:   // nothing to do, but check whether it's time to scan again.
             //debug_log("scan idle\r\n");
-            if(millis() - lastScanTime >= scanTiming.period)  // start scanning if it's time to scan
+            if(scan_enable)  // don't re-start scans if scanning is disabled
             {
-                startScan(scanTiming.interval,scanTiming.window,scanTiming.timeout);
+                if(millis() - lastScanTime >= scanTiming.period)  // start scanning if it's time to scan
+                {
+                    startScan(scanTiming.interval,scanTiming.window,scanTiming.timeout);
+                }
             }
             break;
         case SCAN_SCANNING:    // nothing to do, timeout callback will stop scans when it's time

--- a/firmware/nRF_badge/data_collector/incl/scanning.h
+++ b/firmware/nRF_badge/data_collector/incl/scanning.h
@@ -269,7 +269,7 @@ typedef union
  
 
 
-
+volatile bool scan_enable;
 
 // For keeping track of current state of scanning
 typedef enum scan_state_t

--- a/firmware/nRF_badge/data_collector/incl/self_test.c
+++ b/firmware/nRF_badge/data_collector/incl/self_test.c
@@ -26,11 +26,13 @@ bool testInternalFlash(void)
 
 bool testExternalFlash(void)
 {
+    
     // unlock flash
     uint32_t stat = ext_flash_global_unprotect();
     if (stat != EXT_FLASH_SUCCESS) {
         return false;
     }
+    ext_flash_wait(); // wait for unlock to finish
 
     // erase the first data block
     stat = ext_flash_block_erase(0);
@@ -41,7 +43,7 @@ bool testExternalFlash(void)
     ext_flash_wait(); // wait for erase to finish
 
     // write to the first block and test the result  
-    unsigned char value[8] = {0,0,0,0,1,2,3,4};
+    unsigned char value[8] = {0,0,0,0,1,2,3,4};  // includes padding bytes
     stat = ext_flash_write(0,value,sizeof(value));
     if (stat != EXT_FLASH_SUCCESS) {
         return false;
@@ -50,7 +52,7 @@ bool testExternalFlash(void)
     ext_flash_wait(); // wait for write to finish
 
     /* not getting what I expected */
-    unsigned char buf[8];
+    unsigned char buf[8];  // includes padding bytes
     stat = ext_flash_read(0,buf,sizeof(buf));               
     if (stat != EXT_FLASH_SUCCESS) {
         return false;
@@ -78,7 +80,7 @@ void testMicAddSample() {
     unsigned int micValue = readingsSum / readingsCount;
     uint8_t reading = micValue <= 255 ? micValue : 255;  //clip reading
 
-    threshold_buffer.pos = (threshold_buffer.pos + 1) % THRESH_BUFSIZE;;
+    threshold_buffer.pos = (threshold_buffer.pos + 1) % THRESH_BUFSIZE;
     threshold_buffer.bytes[threshold_buffer.pos] = reading;
     debug_log("added : %d\r\n", reading);
 }


### PR DESCRIPTION
Scanning disabled by default (currently no way to re-enable at runtime—will be implemented with extended badge BLE communication protocol)
Added more helpful #defines for external flash opcodes and status register flags.
A couple extra comments on the self-test code.