### PR TITLE
Fixed timewarp bug.

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.h
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.h
@@ -27,6 +27,7 @@ void rtc_config(void);
 
 /**
  * set a compare interrupt to occur a number of milliseconds from now (i.e. to break from sleep)
+ * NOTE: Maximum countdown time is 130 seconds.
  */
 void countdown_set(unsigned long ms);
 
@@ -34,7 +35,7 @@ void countdown_set(unsigned long ms);
 /**
  * returns 32768Hz ticks of RTC, extended to 43 bits  (from built-in 24 bits)
  */
-unsigned long ticks(void);
+unsigned long long ticks(void);
 
 /**
  * emulate functionality of millis() in arduino


### PR DESCRIPTION
In time/counter handling code, main 32768Hz counter was mistakenly cast to an unsigned long, instead of unsigned long long.  Resulting overflow caused erroneous millis() values, leading to incorrect evaluations of now().

Note: verified by initiating counter to ~2 minutes before the problem time.  Bug occurred after ~2minutes under this condition; the fix prevents the bug from occurring.
The fix has not been truly verified with the counter initiated from 0 as normal.  (it takes about ~36 hours to encounter the bug in this case).  To be 100% safe, this could be verified before merging; but it is unlikely that the minor edits made here would break anything.