### PR TITLE
Analog pin definitions

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/analog.h
+++ b/firmware/nRF_badge/data_collector/incl/analog.h
@@ -11,22 +11,10 @@
 
 #include "debug_log.h"
 
-#if defined(BOARD_BADGE_03)
-  #define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
-  #define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF0  //GPIO P00
-  
-#elif defined(BOARD_BADGE_03V2_RIGADO)
-  #define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
-  #define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF1  //GPIO P06
-  
-#elif defined(BOARD_BADGE_03V2_DYNASTREAM)
-  #define MIC_PIN ADC_CONFIG_PSEL_AnalogInput2  //GPIO P01
-  #define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF0  //GPIO P00
-  
-#else    // NRF51DK, or an unspecified board
-  #define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
-  #define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF0  //GPIO P00
-  
+// Should be defined in custom board files.  (default values here in case, e.g., programming NRFDK board)
+#if !(defined(MIC_PIN) && defined(MIC_AREF))
+    #define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
+    #define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF1  //GPIO P06
 #endif
 
 

--- a/firmware/nRF_badge/data_collector/incl/badge_03.h
+++ b/firmware/nRF_badge/data_collector/incl/badge_03.h
@@ -43,4 +43,8 @@
 #define SPIM0_SCK_PIN   2    // SPI clock signal. 
 
 
+#define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
+#define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF0  //GPIO P00
+
+
 #endif // BADGE_03_H

--- a/firmware/nRF_badge/data_collector/incl/badge_03v2_dynastream.h
+++ b/firmware/nRF_badge/data_collector/incl/badge_03v2_dynastream.h
@@ -42,4 +42,8 @@
 #define SPIM0_SCK_PIN   5    // SPI SCK signal. 
 
 
+#define MIC_PIN ADC_CONFIG_PSEL_AnalogInput2  //GPIO P01
+#define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF0  //GPIO P00
+
+
 #endif // BADGE_03V2_DYNASTREAM_H

--- a/firmware/nRF_badge/data_collector/incl/badge_03v2_rigado.h
+++ b/firmware/nRF_badge/data_collector/incl/badge_03v2_rigado.h
@@ -41,4 +41,8 @@
 #define SPIM0_SCK_PIN   3    // SPI SCK signal. 
 
 
+#define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
+#define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF1  //GPIO P06
+
+
 #endif // BADGE_03V2_RIGADO_H

--- a/firmware/nRF_badge/data_collector/incl/badge_03v4.h
+++ b/firmware/nRF_badge/data_collector/incl/badge_03v4.h
@@ -47,4 +47,8 @@
 #define TWI_SCL_PIN 3       // I2C SCL pin (same pin as SPI clock)
 
 
+#define MIC_PIN ADC_CONFIG_PSEL_AnalogInput6  //GPIO P05
+#define MIC_AREF NRF_ADC_CONFIG_REF_EXT_REF1  //GPIO P06
+
+
 #endif // BADGE_03V4


### PR DESCRIPTION
Move MIC_PIN and MIC_AREF definitions to board config files, for consistency.  (were in analog.h, sloppy).  Also added these pin definitions for badge_03v4.