### PR TITLE
Added badge connection timeout - disconnects if server stalls.

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/ble_setup.c
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.c
@@ -277,6 +277,11 @@ void BLEresume()
     BLEbegin();
 }
 
+void BLEforceDisconnect()
+{
+    sd_ble_gap_disconnect(m_conn_handle,BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+}
+
 
 bool notificationEnabled()  {
     return m_nus.is_notification_enabled;

--- a/firmware/nRF_badge/data_collector/incl/ble_setup.h
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.h
@@ -149,6 +149,11 @@ void BLEdisable();
 void BLEresume();
 
 /**
+ * Disconnect from server forcefully.
+ */
+void BLEforceDisconnect();
+
+/**
  * Functions called on connection or disconnection events
  */
 void BLEonConnect();

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.c
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.c
@@ -20,6 +20,12 @@ void rtc_handler(nrf_drv_rtc_int_type_t int_type)
         //debug_log("Countdown end\r\n");
         countdownOver = true;
     }
+    else if(int_type == NRF_DRV_RTC_INT_COMPARE1)  //countdown timer interrupt
+    {
+        nrf_drv_rtc_cc_disable(&rtc, 1);  //disable the compare channel - countdown is finished
+        //debug_log("BLE connection timeout.\r\n");
+        ble_timeout = true;
+    }
 }
  
 void rtc_config(void)
@@ -53,6 +59,18 @@ void countdown_set(unsigned long ms)
     unsigned long compareTicks = (nrf_drv_rtc_counter_get(&rtc) + (32768UL * ms / 1000UL));  //convert ms to ticks
     compareTicks &= 0xffffff; //clip to 24bits
     nrf_drv_rtc_cc_set(&rtc,0,compareTicks,true);  //set compare channel 0 to interrupt when counter hits compareTicks
+}
+
+void ble_timeout_set(unsigned long ms)
+{
+    if(ms > 130000UL)  {  // 130 seconds.
+        ms = 130000UL;  // avoid overflow in calculation of compareTicks below.
+    }
+    //Set compare value so that an interrupt will occur ms milliseconds from now
+    ble_timeout = false;
+    unsigned long compareTicks = (nrf_drv_rtc_counter_get(&rtc) + (32768UL * ms / 1000UL));  //convert ms to ticks
+    compareTicks &= 0xffffff; //clip to 24bits
+    nrf_drv_rtc_cc_set(&rtc,1,compareTicks,true);  //set compare channel 1 to interrupt when counter hits compareTicks
 }
 
 unsigned long long ticks(void)  {

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.h
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.h
@@ -11,6 +11,7 @@
 #include "debug_log.h"
 
 volatile bool countdownOver;  //set true when the countdown interrupt triggers
+volatile bool ble_timeout;
 
 /**
  * rtc event handler function
@@ -30,6 +31,11 @@ void rtc_config(void);
  * NOTE: Maximum countdown time is 130 seconds.
  */
 void countdown_set(unsigned long ms);
+
+/**
+ * similar to countdown_set, but used to keep track of BLE connection timeout.
+ */
+void ble_timeout_set(unsigned long ms);
 
 
 /**


### PR DESCRIPTION
Badge disconnects if CONNECTION_TIMEOUT_MS milliseconds have passed since last BLE activity (connect/receive).

Slightly hack-y; implemented as a timer interrupt, so that the BLE timeout occurs even if the badge is sleeping.  (as opposed to something implemented entirely within the main loop)