### PR TITLE
Badge connection timeout - disconnect if server stalls

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/ble_setup.c
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.c
@@ -297,6 +297,7 @@ bool BLEwrite(uint8_t* data, uint16_t len)  {
         //Can happen frequently while trying to send a large chunk of data
         return false;
     }
+    ble_timeout_set(CONNECTION_TIMEOUT_MS);
     return true;
 }
 

--- a/firmware/nRF_badge/data_collector/incl/ble_setup.c
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.c
@@ -277,6 +277,11 @@ void BLEresume()
     BLEbegin();
 }
 
+void BLEforceDisconnect()
+{
+    sd_ble_gap_disconnect(m_conn_handle,BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
+}
+
 
 bool notificationEnabled()  {
     return m_nus.is_notification_enabled;

--- a/firmware/nRF_badge/data_collector/incl/ble_setup.h
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.h
@@ -16,6 +16,7 @@
 #include "ble_nus.h"  //Nordic UART service
  
 #include "internal_flash.h"
+#include "rtc_timing.h"
  
 #define IS_SRVC_CHANGED_CHARACT_PRESENT 0                                           /**< Include or not the service_changed characteristic. if not enabled, the server's database cannot be changed for the lifetime of the device*/
 

--- a/firmware/nRF_badge/data_collector/incl/ble_setup.h
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.h
@@ -149,6 +149,11 @@ void BLEdisable();
 void BLEresume();
 
 /**
+ * Disconnect from server forcefully.
+ */
+void BLEforceDisconnect();
+
+/**
  * Functions called on connection or disconnection events
  */
 void BLEonConnect();

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.c
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.c
@@ -20,6 +20,12 @@ void rtc_handler(nrf_drv_rtc_int_type_t int_type)
         //debug_log("Countdown end\r\n");
         countdownOver = true;
     }
+    else if(int_type == NRF_DRV_RTC_INT_COMPARE1)  //countdown timer interrupt
+    {
+        nrf_drv_rtc_cc_disable(&rtc, 1);  //disable the compare channel - countdown is finished
+        //debug_log("BLE connection timeout.\r\n");
+        ble_timeout = true;
+    }
 }
  
 void rtc_config(void)
@@ -53,6 +59,18 @@ void countdown_set(unsigned long ms)
     unsigned long compareTicks = (nrf_drv_rtc_counter_get(&rtc) + (32768UL * ms / 1000UL));  //convert ms to ticks
     compareTicks &= 0xffffff; //clip to 24bits
     nrf_drv_rtc_cc_set(&rtc,0,compareTicks,true);  //set compare channel 0 to interrupt when counter hits compareTicks
+}
+
+void ble_timeout_set(unsigned long ms)
+{
+    if(ms > 130000UL)  {  // 130 seconds.
+        ms = 130000UL;  // avoid overflow in calculation of compareTicks below.
+    }
+    //Set compare value so that an interrupt will occur ms milliseconds from now
+    ble_timeout = false;
+    unsigned long compareTicks = (nrf_drv_rtc_counter_get(&rtc) + (32768UL * ms / 1000UL));  //convert ms to ticks
+    compareTicks &= 0xffffff; //clip to 24bits
+    nrf_drv_rtc_cc_set(&rtc,1,compareTicks,true);  //set compare channel 1 to interrupt when counter hits compareTicks
 }
 
 unsigned long long ticks(void)  {

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.c
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.c
@@ -22,7 +22,7 @@ void rtc_handler(nrf_drv_rtc_int_type_t int_type)
     }
     else if(int_type == NRF_DRV_RTC_INT_COMPARE1)  //countdown timer interrupt
     {
-        nrf_drv_rtc_cc_disable(&rtc, 1);  //disable the compare channel - countdown is finished
+        nrf_drv_rtc_cc_disable(&rtc, 1);  //disable the compare channel - timeout
         //debug_log("BLE connection timeout.\r\n");
         ble_timeout = true;
     }
@@ -71,6 +71,11 @@ void ble_timeout_set(unsigned long ms)
     unsigned long compareTicks = (nrf_drv_rtc_counter_get(&rtc) + (32768UL * ms / 1000UL));  //convert ms to ticks
     compareTicks &= 0xffffff; //clip to 24bits
     nrf_drv_rtc_cc_set(&rtc,1,compareTicks,true);  //set compare channel 1 to interrupt when counter hits compareTicks
+}
+
+void ble_timeout_cancel()
+{
+    nrf_drv_rtc_cc_disable(&rtc, 1);  //disable the compare channel - timeout canceled
 }
 
 unsigned long long ticks(void)  {

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.h
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.h
@@ -11,6 +11,7 @@
 #include "debug_log.h"
 
 volatile bool countdownOver;  //set true when the countdown interrupt triggers
+volatile bool ble_timeout;
 
 /**
  * rtc event handler function
@@ -30,6 +31,11 @@ void rtc_config(void);
  * NOTE: Maximum countdown time is 130 seconds.
  */
 void countdown_set(unsigned long ms);
+
+/**
+ * similar to countdown_set, but used to keep track of BLE connection timeout.
+ */
+void ble_timeout_set(unsigned long ms);
 
 
 /**

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.h
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.h
@@ -37,6 +37,11 @@ void countdown_set(unsigned long ms);
  */
 void ble_timeout_set(unsigned long ms);
 
+/**
+ * cancel the ble timeout counter
+ */
+void ble_timeout_cancel();
+
 
 /**
  * returns 32768Hz ticks of RTC, extended to 43 bits  (from built-in 24 bits)

--- a/firmware/nRF_badge/data_collector/incl/rtc_timing.h
+++ b/firmware/nRF_badge/data_collector/incl/rtc_timing.h
@@ -13,6 +13,8 @@
 volatile bool countdownOver;  //set true when the countdown interrupt triggers
 volatile bool ble_timeout;
 
+#define CONNECTION_TIMEOUT_MS 5000UL
+
 /**
  * rtc event handler function
  * For extending the 24-bit hardware clock, by incrementing a larger number every time it overflows

--- a/firmware/nRF_badge/data_collector/main.c
+++ b/firmware/nRF_badge/data_collector/main.c
@@ -95,7 +95,6 @@ volatile unsigned long dataTimestamp;    // holds the date
 
 volatile bool sleep = false;  //whether we should sleep (so actions like data sending can override sleep)
 
-const unsigned long CONNECTION_TIMEOUT_MS = 5000;
 
 
 //=========================== Global function definitions ==================================

--- a/firmware/nRF_badge/data_collector/main.c
+++ b/firmware/nRF_badge/data_collector/main.c
@@ -572,6 +572,8 @@ void BLEonDisconnect()
 
     // for app development. disable if forgotten in prod. version
     nrf_gpio_pin_write(LED_1,LED_OFF);
+    
+    ble_timeout_cancel();
 }
 
 /** Function for handling incoming data from the BLE UART service


### PR DESCRIPTION
Badge disconnects if CONNECTION_TIMEOUT_MS milliseconds have passed since last BLE activity (connect/receive).

Slightly hack-y; implemented as a timer interrupt, so that the BLE timeout occurs even if the badge is sleeping. (as opposed to something implemented entirely within the main loop).