### PR TITLE
Store only top 29 devices from scan by RSSI

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/scanner.c
+++ b/firmware/nRF_badge/data_collector/incl/scanner.c
@@ -258,11 +258,11 @@ static int compareSeenDeviceByRSSI(const void * a, const void * b) {
     seenDevice_t * seenDeviceB = (seenDevice_t *) b;
 
     if (seenDeviceA->rssi > seenDeviceB->rssi) {
-        return -1;
+        return -1; // We want device A before device B in our list.
     } else if (seenDeviceA->rssi == seenDeviceB->rssi) {
-        return 0;
+        return 0; // We don't care whether deviceA or deviceB comes first.
     } else if (seenDeviceA->rssi < seenDeviceB->rssi) {
-        return 1;
+        return 1; // We want device A to come after device B in our list.
     }
 
     // We should never get here?

--- a/firmware/nRF_badge/data_collector/incl/scanner.c
+++ b/firmware/nRF_badge/data_collector/incl/scanner.c
@@ -39,6 +39,7 @@ void scanner_init()
     //scan_state = SCAN_IDLE;
 }
 
+
 uint32_t startScan()
 {
     sd_ble_gap_scan_stop();  // stop any in-progress scans
@@ -92,7 +93,7 @@ void BLEonAdvReport(ble_gap_evt_adv_report_t* advReport)
             memcpy(&badgeAdvData,&manufDataPtr[2],CUSTOM_ADV_DATA_LEN);  // skip past company ID; ensure data is properly aligned
             ID = badgeAdvData.ID;
             group = badgeAdvData.group;
-            //debug_log("---Badge seen: group %d, ID %.4X, rssi %d.\r\n",(int)group,(int)ID,(int)rssi);
+            debug_log("---Badge seen: group %d, ID %.4X, rssi %d.\r\n",(int)group,(int)ID,(int)rssi);
         }
     }
     else if (manufDataLen == IBEACON_MANUF_DATA_LEN)  {

--- a/firmware/nRF_badge/data_collector/incl/scanner.c
+++ b/firmware/nRF_badge/data_collector/incl/scanner.c
@@ -39,59 +39,6 @@ void scanner_init()
     //scan_state = SCAN_IDLE;
 }
 
-static ble_gap_evt_adv_report_t get_mock_adv_report_for_badge_with_id(uint8_t id) {
-    // Generate MAC address based on id.
-    uint8_t peer_addr_based_on_id[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, id};
-
-    ble_gap_evt_adv_report_t mock_adv_report;
-
-    mock_adv_report.peer_addr.addr_type = BLE_GAP_ADDR_TYPE_PUBLIC;
-    memcpy(mock_adv_report.peer_addr.addr, peer_addr_based_on_id, sizeof(mock_adv_report.peer_addr.addr));
-
-    // Our mock reports are used to simulate scanning, so we don't need to include
-    // a report_type.
-    mock_adv_report.scan_rsp = 1;
-    mock_adv_report.rssi = -100 + id;
-
-    // Create a mock device name.
-    typedef struct {
-        uint8_t name_length;
-        uint8_t name_type;
-        char name[sizeof(DEVICE_NAME)];
-    }__attribute__((packed)) badge_name_data_t;
-
-    badge_name_data_t badge_name_data;
-    badge_name_data.name_length = sizeof(DEVICE_NAME);
-    badge_name_data.name_type = BLE_GAP_AD_TYPE_COMPLETE_LOCAL_NAME;
-    memcpy(badge_name_data.name, DEVICE_NAME, sizeof(DEVICE_NAME));
-
-    // Create mock custom manufacturer data for a badge.
-    typedef struct {
-        uint8_t manufacturer_data_len;
-        uint8_t data_type;
-        uint16_t company_id;
-        custom_adv_data_t manufacturer_data;
-    }__attribute__((packed)) manufacturer_adv_data_t;
-
-    manufacturer_adv_data_t mock_manufacturer_adv_data;
-    mock_manufacturer_adv_data.data_type = BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA;
-    mock_manufacturer_adv_data.company_id = 0xFF;
-    mock_manufacturer_adv_data.manufacturer_data_len = 14;
-
-    mock_manufacturer_adv_data.manufacturer_data.battery = 90;
-    mock_manufacturer_adv_data.manufacturer_data.group = badgeAssignment.group;
-    mock_manufacturer_adv_data.manufacturer_data.ID = id;
-    memcpy(mock_manufacturer_adv_data.manufacturer_data.MAC, peer_addr_based_on_id, sizeof(peer_addr_based_on_id));
-    mock_manufacturer_adv_data.manufacturer_data.statusFlags = 0x00;
-
-    // Copy device name and manufacturer data into report advertising data.
-    memcpy(&mock_adv_report.data[0], &badge_name_data, sizeof(badge_name_data_t));
-    memcpy(&mock_adv_report.data[sizeof(badge_name_data)], &mock_manufacturer_adv_data, sizeof(mock_manufacturer_adv_data));
-    mock_adv_report.dlen = sizeof(badge_name_data) + sizeof(mock_manufacturer_adv_data);
-
-    return mock_adv_report;
-}
-
 uint32_t startScan()
 {
     sd_ble_gap_scan_stop();  // stop any in-progress scans
@@ -361,11 +308,6 @@ bool updateScanner()
                     if(result == NRF_SUCCESS)  {
                         scan_state = SCANNER_SCANNING;
                         debug_log("SCANNER: Started scan.\r\n");
-
-                        for (int i = 0; i < 105; i++) {
-                            ble_gap_evt_adv_report_t adv_report = get_mock_adv_report_for_badge_with_id(i);
-                            BLEonAdvReport(&adv_report);
-                        }
                     }
                     else  {
                         debug_log("ERR: error starting scan, #%u\r\n",(unsigned int)result);

--- a/firmware/nRF_badge/data_collector/incl/scanner.h
+++ b/firmware/nRF_badge/data_collector/incl/scanner.h
@@ -181,7 +181,7 @@ volatile scan_state_t scan_state;
 
 
 
-#define MAX_SCAN_RESULTS 28     // maximum number of devices that will be reported in a scan
+#define MAX_SCAN_RESULTS 100     // maximum number of devices that will be reported in a scan
                                 // ^^ temporarily capped to never be more than one chunk's worth
 #define MAX_SCAN_COUNT 127      // maximum number of RSSI readings for one device reported in a scan
 

--- a/firmware/nRF_badge/data_collector/main.c
+++ b/firmware/nRF_badge/data_collector/main.c
@@ -165,9 +165,9 @@ int main(void)
     // Blink once on start
     nrf_gpio_pin_write(LED_1,LED_OFF);
     nrf_delay_ms(200);
-    nrf_gpio_pin_write(LED_1,LED_ON);
+    nrf_gpio_pin_write(LED_2,LED_ON);
     nrf_delay_ms(200);
-    nrf_gpio_pin_write(LED_1,LED_OFF);
+    nrf_gpio_pin_write(LED_2,LED_OFF);
     nrf_delay_ms(200);
     nrf_gpio_pin_write(LED_1,LED_ON);
     nrf_delay_ms(200);


### PR DESCRIPTION
This commit changes the scanner to only store the top 29 devices (SCAN_DEVICES_PER_CHUNK) in any scan. This should allow us to deal with situations where there are many nearby devices without having to make major codebase changes.

This change functions by sorting the scan struct by RSSI and then setting scan.num to truncate the struct. We only do this if there were more than SCAN_DEVICES_PER_CHUNK in a scan, so the behavior in any other case is unchanged. 

**Testing Methodology:**

For a given test I:

1. Used the `get_mock_adv_report_for_badge_with_id(id)` function to generate mock BLE advertising reports for the specified number of devices. (The code for this function can be viewed in commit f3bf81a that removed it, but in short in mocked a device with id `id` and RSSI `-100 + id`.
2. Watched the UART logs to ensure that the specified number of devices were stored correctly, verifying expected RSSI vs ID.
3. Requested the data for that scan over BLE, and ensured the scan contained the correct number of devices with the expected RSSI - ID pairings.

I performed this test for the number of scan devices = 0, 1, 28 (just under one chunk), 29 (one chunk exactly), 30 (one chunk plus one device), 50 (one chunk plus some), 100 (max num devices per scan), and 105 (excess of max num devices per scan, additional devices should just be ignored).

I also performed an additional test where I mocked out some devices in addition to the iBeacon I had, which verified the code worked with an iBeacon, and that the sorting works even when two devices have the same RSSI.