### PR TITLE
Fix for advertising issue

### DIFF
--- a/firmware/nRF_badge/data_collector/incl/ble_setup.c
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.c
@@ -416,7 +416,7 @@ void BLEresume(ble_pauseReq_src source)
         if(pauseRequest[src]) return;  // if any pending pause requests, don't restart advertising
     }
     // If no pending pause requests, restart advertising.
-    setAdvData();
+    if (needAdvDataUpdate) setAdvData();
     BLEstartAdvertising();
 }
 

--- a/firmware/nRF_badge/data_collector/incl/ble_setup.c
+++ b/firmware/nRF_badge/data_collector/incl/ble_setup.c
@@ -416,6 +416,7 @@ void BLEresume(ble_pauseReq_src source)
         if(pauseRequest[src]) return;  // if any pending pause requests, don't restart advertising
     }
     // If no pending pause requests, restart advertising.
+    setAdvData();
     BLEstartAdvertising();
 }
 


### PR DESCRIPTION
I haven't extensively tested this, but this appears to resolve issue #66.

The issue seems to be caused by advertising be paused by the storer whenever the timeout event happens. Really, we should update our advertising data whenever we resume back to advertising.